### PR TITLE
Chat: Refactor chat filter out of Config (#3868)

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -1298,7 +1298,7 @@ let commands = {
 	},
 };
 
-Chat.loadCommands();
+Chat.loadPlugins();
 Chat.commands.tour = 'tournament';
 Chat.commands.tours = 'tournament';
 Chat.commands.tournaments = 'tournament';


### PR DESCRIPTION
This allows chat-plugins to export a 'chatfilter' function to alter the chatfilter.

This keeps support for Config.chatfilter as well; it adds it to the array of Chat.filters

Note:
1. returning a string in a chatfilter will make that user's message said string
2. returning false will make a user's message not send
3. returning undefined will send a user's original message to the room